### PR TITLE
Added gpio_pin_reset for gpio pins of clk and data

### DIFF
--- a/tm1637.c
+++ b/tm1637.c
@@ -101,6 +101,8 @@ void tm1637_send_byte(tm1637_led_t * led, uint8_t byte)
     // CLK after sending the 8th bit, to the next falling edge of CLK.
     // DIO needs to be set as input during this time to avoid having both
     // chips trying to drive DIO at the same time.
+    gpio_reset_pin(pin_clk);
+    gpio_reset_pin(pin_data);
     gpio_set_direction(led->m_pin_dta, GPIO_MODE_INPUT);
     gpio_set_level(led->m_pin_clk, 0); // TM1637 starts ACK (pulls DIO low)
     tm1637_delay();


### PR DESCRIPTION
This change helped me to run this driver into esp32c6 dev board. Since the gpio pins for clk and data are directly set, there seems to be some issue with the initialization process. So with the help of the reset api, everything seems to be working fine